### PR TITLE
tasklist.fbs with/without :sync

### DIFF
--- a/examples/cpp-gen/tasklist.fbs
+++ b/examples/cpp-gen/tasklist.fbs
@@ -1,4 +1,3 @@
-/// objectbox:sync
 table Task {
     id: ulong;
     text: string;


### PR DESCRIPTION
This example has 2 apps, one without sync and another with sync.
This file is currently being shared in the examples/cpp-gen folder. But, with this: "/// objectbox:sync" directive it can't be used on the main.cpp (without sync) example.
We must separate the folders (examples/cpp-gen-no-sync, examples/cpp-gen-sync) or generate specific .fbs file on the CMakeLists.txt